### PR TITLE
Fix empty epoch reporting

### DIFF
--- a/consensus-client-it/src/test/scala/units/EmptyEpochMinerEvictionTestSuite.scala
+++ b/consensus-client-it/src/test/scala/units/EmptyEpochMinerEvictionTestSuite.scala
@@ -2,6 +2,7 @@ package units
 
 import com.wavesplatform.account.Address
 import com.wavesplatform.state.{Height, IntegerDataEntry, StringDataEntry}
+import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.transaction.TxHelpers
 
 class EmptyEpochMinerEvictionTestSuite extends BaseDockerTestSuite {
@@ -34,9 +35,10 @@ class EmptyEpochMinerEvictionTestSuite extends BaseDockerTestSuite {
         // Wait for another idle miner epoch
         waves1.api.waitForHeight(prevReportedHeight + 1)
         chainContract.waitForMinerEpoch(idleMiner)
-
+        val lastWavesBlock = waves1.api.blockHeader(waves1.api.height()).value
+        val vrf            = ByteStr.decodeBase58(lastWavesBlock.VRF).get
         // Report empty epoch
-        val reportResult = waves1.api.broadcastAndWait(ChainContract.reportEmptyEpoch(reporter))
+        val reportResult = waves1.api.broadcastAndWait(ChainContract.reportEmptyEpoch(reporter, vrf))
         reportResult.height
       })
 

--- a/contracts/waves/src/main.ride
+++ b/contracts/waves/src/main.ride
@@ -1093,7 +1093,8 @@ func setup(genesisBlockHashHex: String, minerRewardInGwei: Int, daoAddress: Stri
 }
 
 @Callable(i)
-func reportEmptyEpoch() = {
+func reportEmptyEpoch(vrf: ByteVector) = {
+  strict checkEpoch      = ensureCorrectEpoch(vrf)
   strict checkEpochEmpty = match epochMeta(height) {
     case u: Unit => unit
     case _ => throw("Current epoch is non-empty")

--- a/src/test/scala/units/client/contract/HasConsensusLayerDappTxHelpers.scala
+++ b/src/test/scala/units/client/contract/HasConsensusLayerDappTxHelpers.scala
@@ -360,10 +360,11 @@ trait HasConsensusLayerDappTxHelpers {
         fee = withdrawFee
       )
 
-    def reportEmptyEpoch(minerAccount: KeyPair): InvokeScriptTransaction = TxHelpers.invoke(
+    def reportEmptyEpoch(minerAccount: KeyPair, vrf: ByteStr = currentHitSource): InvokeScriptTransaction = TxHelpers.invoke(
       invoker = minerAccount,
       dApp = chainContractAddress,
       func = "reportEmptyEpoch".some,
+      args = List(Terms.CONST_BYTESTR(vrf).explicitGet()),
       fee = reportEmptyEpochFee
     )
 


### PR DESCRIPTION
- Add vrf to `reportEmptyEpoch` callable function to make sure it's called in the correct epoch and avoid spending reporting tx fees on epoch mismatches
- Adjust integration test