### PR TITLE
Add an inifinite loop example

### DIFF
--- a/src/test/scala/units/UnitsConvert.scala
+++ b/src/test/scala/units/UnitsConvert.scala
@@ -1,0 +1,19 @@
+package units
+
+import org.web3j.utils.Convert
+import units.eth.Gwei
+
+object UnitsConvert {
+  def toUnitsInWaves(userAmount: BigDecimal): Long               = toWavesAtomic(userAmount, TestDefaults.NativeTokenClDecimals)
+  def toWavesAtomic(userAmount: BigDecimal, decimals: Int): Long = toAtomic(userAmount, decimals).bigInteger.longValueExact()
+
+  def toWei(userAmount: BigDecimal): BigInt = Convert.toWei(userAmount.bigDecimal, Convert.Unit.ETHER).toBigIntegerExact
+  def toGwei(userAmount: BigDecimal): Gwei = {
+    val rawWei  = Convert.toWei(userAmount.bigDecimal, Convert.Unit.ETHER)
+    val rawGwei = Convert.fromWei(rawWei, Convert.Unit.GWEI).longValue()
+    Gwei.ofRawGwei(rawGwei)
+  }
+
+  def toAtomic(userAmount: BigDecimal, decimals: Int): BigInt = userAmount.bigDecimal.scaleByPowerOfTen(decimals).toBigIntegerExact
+  def toUser(atomic: BigInt, decimals: Int): BigDecimal       = BigDecimal(atomic).bigDecimal.scaleByPowerOfTen(-decimals)
+}


### PR DESCRIPTION
```
2025-06-10 17:45:49,877 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:49,992 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:49,992 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:50,188 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:50,189 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:51,330 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 2U63WtZtLX873KPBmNGZu9qpTiseGXYep4cKNvF6xwou evaluated to Right(true)
2025-06-10 17:45:51,394 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction GRwhvghvPC5PUgNwmFwdv5hffYK3jgWSBEAB7eHf4Dez evaluated to Right(true)
2025-06-10 17:45:51,399 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 2QD8eBmn3kKz6K5r7oytRaRK2cQNKTdx7Cwo181GBAnHCn1HLPMUk7UHRR1bTWqUzEkG6Frxb8DoiB9UfdShQRJR, discarded microblock refs: []
2025-06-10 17:45:51,445 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:51,446 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:51,447 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:51,469 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction J2CWa6FLbbs7cz2KT7FzaPrPamGCdNatPBqngf4LiZbt evaluated to Right(true)
2025-06-10 17:45:51,475 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 6S2TnVZCSWD9FpDw5Vmf3ac8pR9QWaY5ubVWdF5oxxhq evaluated to Right(true)
2025-06-10 17:45:51,481 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(CdGZRzv... -> zczrh1T..., txs=3) appended, diff=d98d9e7e
2025-06-10 17:45:51,501 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(6HdoVAC... -> CdGZRzv..., txs=1) appended, diff=c5ad00d1
2025-06-10 17:45:51,502 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:51,502 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:51,520 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:51,522 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:51,522 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:51,525 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:51,525 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:51,726 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction AbwDLVjmJgHuFuDcZVTJ8RPZH4VSQRoLhPMtr7QidbQU evaluated to Right(true)
2025-06-10 17:45:51,731 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 3DmjSUmDsJ6q1vJ8XzJTy7eZ8rqJ7x8BdnMFcb3ZqjBR evaluated to Right(true)
2025-06-10 17:45:51,734 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block xKwYiJJ58cn5zyVVJwZSXMSiRa42Hx8uawBNtai5fnCC6PhuprzXus7H9qe4BNv9cUkR4oYeap9u1NezhrwqUAn, discarded microblock refs: []
2025-06-10 17:45:51,736 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:51,736 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:51,737 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:51,746 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction gNqwGQCywDuL3ANuvxKo29xSs83aa3pj9h7pva67Rrd evaluated to Right(true)
2025-06-10 17:45:51,752 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction Gn5AT1VNo2NZGeybtjaJ3kfXf2R5vym6Jaymb1XaHFgP evaluated to Right(true)
2025-06-10 17:45:51,754 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(GRpC1HB... -> 6uHiiGr..., txs=3) appended, diff=bedd226e
2025-06-10 17:45:51,841 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:51,841 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:51,842 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:51,844 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:51,844 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:51,847 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:51,847 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:52,022 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction CdRsybe982gqxwCuwaxvVYp5SP7rLxufAWhKtwexh5bS evaluated to Right(true)
2025-06-10 17:45:52,027 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 5w2jDyc2LN4UAs4KUphAYgHUs4NUoHVJZJhZMdKUi8wR evaluated to Right(true)
2025-06-10 17:45:52,030 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 4JiQUqcuh8xKizENibY9asEGvTXjVLQWvieCBht8WPAwhaWpxP4svbdYnoBcun5HZpHQLq5MeeFfK6xkdZ2iiyCE, discarded microblock refs: []
2025-06-10 17:45:52,032 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:52,032 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:52,032 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:52,036 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 98zqbkt8ZPDhQAuxvLBXZiAJCqRCp9Br71NjiKuNqoe2 evaluated to Right(true)
2025-06-10 17:45:52,037 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 9g67p2CeDfGqhB4TpTdM3PoRQUJFSe4kTeqprnBgoKop evaluated to Right(true)
2025-06-10 17:45:52,038 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(CxM22L9... -> YHjnTDX..., txs=3) appended, diff=21a7fa3c
2025-06-10 17:45:52,042 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:52,042 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:52,043 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:52,045 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:52,045 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:52,047 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:52,047 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:52,239 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction Gx1KNR3w9phWDj9Ly2wC3dj4oZDnr1UWEiX7LJZW5vDr evaluated to Right(true)
2025-06-10 17:45:52,243 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction HYNzvWLN6wVcmYx54LCGULJLDaMJzJbgG4zPMDJBfVC evaluated to Right(true)
2025-06-10 17:45:52,245 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 52yXZAWFHwro9LqS21XQkbXZzZNrCYdqXtpUDPDSqJt5hMZHBARgRc7q6CEaa6oSnq9CjQkYardoJuaQrqVxaq8T, discarded microblock refs: []
2025-06-10 17:45:52,246 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:52,247 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:52,247 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:52,251 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 4hAaAMjkHwhWu3XRUmoTUDF8rAtGAsj4mbsjx4eEH9Ts evaluated to Right(true)
2025-06-10 17:45:52,252 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 4wSxGJDMczSMdd5WKayoh3P9XFuhm72ttBvA1gD7vdXk evaluated to Right(true)
2025-06-10 17:45:52,253 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(6Gs9cV2... -> 26A4zBA..., txs=3) appended, diff=3902c27c
2025-06-10 17:45:52,258 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:52,258 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:52,259 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:52,260 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:52,261 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:52,263 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:52,263 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:52,424 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 2msSpL9ZtJQLFJTWxx7rm6P67cpoa5zbxm22ufBpr5Ui evaluated to Right(true)
2025-06-10 17:45:52,427 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 8nmtvoRfJ978QmRfVoHwHk4GWzTjxVDAGEaAePRUynfd evaluated to Right(true)
2025-06-10 17:45:52,429 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block ZeUesqSGP7BezH4JQrdnXCEzZRxEU2hH8Z2kqJ1HWEYqJaSeErYECuGTZuYJ2QuSmURL2CgweEYTkH4e43XDU11, discarded microblock refs: []
2025-06-10 17:45:52,430 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:52,430 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:52,431 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:52,434 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 773itHE5EdFe2L3aqfvdqeLcRcEu8cu2TJq9iD1t2JBd evaluated to Right(true)
2025-06-10 17:45:52,435 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction CX2yF2rrdqaDLg4bn4Kxoiv75dXhoCDcBN8ePnky2hx evaluated to Right(true)
2025-06-10 17:45:52,436 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(J4ZBscE... -> G2GF9p8..., txs=3) appended, diff=d846b8a1
2025-06-10 17:45:52,439 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:52,439 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:52,440 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:52,442 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:52,442 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:52,444 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:52,444 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:52,609 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction J5JUqSPjTzueeDQSYscBMJg8dGvX9kQmZpsUD2qE8Beq evaluated to Right(true)
2025-06-10 17:45:52,612 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction GmB1fGvp1JU3TiFvcgN24Fq962UWgY7Mc8yFofQ9BDw8 evaluated to Right(true)
2025-06-10 17:45:52,613 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block TzQRRzD7pHKKsaKK7yqpcsSsfhxgqY9k1jA6mtL4voqjc7nyktyippM5nVby7nQbqUQQfQniwvwMq7GtYHBbTdF, discarded microblock refs: []
2025-06-10 17:45:52,614 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:52,615 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:52,615 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:52,618 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 5knRbCjKwk68TDdeLDJFqAxwmEimuSmw8BSD34krYhKW evaluated to Right(true)
2025-06-10 17:45:52,619 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction vxsjwzJCYp8J6f1585VjNuxG8KsiedoGUWbZNPeBFCV evaluated to Right(true)
2025-06-10 17:45:52,620 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(ASZHTqW... -> 67Vqjts..., txs=3) appended, diff=6a2e476b
2025-06-10 17:45:52,623 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:52,623 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:52,625 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:52,626 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:52,626 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:52,628 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:52,628 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:52,792 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction BBN82CGJwDKXCymvHMLsUc1n5w9MYCBHgPDwuFgvAzQm evaluated to Right(true)
2025-06-10 17:45:52,795 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction ERVdwzpKCxPoLG7Luo5zPtTXkfgDaSm9UQ1LZw777f4X evaluated to Right(true)
2025-06-10 17:45:52,796 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 29rr3MJBi61xsKKiQddCsvF6bQY7ezqE5pfSnYaDHvpYi8QNpyTM2HUCZ9y8DsLqG72BDozHjzbaa7ZdSV3BJzqS, discarded microblock refs: []
2025-06-10 17:45:52,797 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:52,798 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:52,798 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:52,800 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(7tYjQq8... -> Dg5FMfX..., txs=1) appended, diff=707291cf
2025-06-10 17:45:52,804 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:52,804 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:52,805 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:52,806 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:52,806 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:52,808 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:52,808 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:52,967 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 9UMYfKutD1R1a1Poso6xuopsXfvziysRxwKhaHdBP7BL evaluated to Right(true)
2025-06-10 17:45:52,969 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 4szhsjR5kR7LeynWVFqhLHupJ5PHDQvS7gS6mbRn2KMu evaluated to Right(true)
2025-06-10 17:45:52,970 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 47VdLQthN7uEJcDGKHe9WTkVPwgeHYom69zdcQFbZLGPGFiRnYYekNaAmUpvJe8p6GCoAaRhakHmwwKJyMSC2d3H, discarded microblock refs: []
2025-06-10 17:45:52,971 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:52,972 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:52,972 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:52,974 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(BJV7tP3... -> HfWr9wH..., txs=1) appended, diff=707291cf
2025-06-10 17:45:52,976 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction HwhqxKnyn7htP3aiEvExBkrHMPxrvXMVsKMLxjRgqFkh evaluated to Right(true)
2025-06-10 17:45:52,977 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:52,977 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:52,978 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:52,979 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:52,979 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:52,982 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:52,982 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:53,144 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction FH852CeZ4W6Eac8t4w7C3ysbErYC6vqLGSQM8RWPQhYW evaluated to Right(true)
2025-06-10 17:45:53,146 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction AHKjEyv5qy2noDgpAbYeLAT1GFkhSaR3PF99XTDcyTey evaluated to Right(true)
2025-06-10 17:45:53,148 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block uz1a9SAUVy4utSKveDkE3fivJgWzzLwQTfPdqujWYPqmZYAGvmkjDipGd4N9AJKMKABRFLVcfw1hFR4pzcyE6UJ, discarded microblock refs: []
2025-06-10 17:45:53,149 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:53,149 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:53,149 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:53,152 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:53,152 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:53,155 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:53,156 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:53,156 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:53,158 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:53,158 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:53,321 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 8nCNDDUD44tnX9Z57NA7Gms1YF6N6mRZBAaH1NDrR9ZP evaluated to Right(true)
2025-06-10 17:45:53,323 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction AGo3giuwbQnRy1Tv9SXpA9knGkqwmMSHpkQA9sjDXKHt evaluated to Right(true)
2025-06-10 17:45:53,324 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block MDpfEt1AQTuxszBp1m6UZVoZiCxN9hUXSWTy57DdPLzU1jJ6hny948WERGgzhCW7fx5SMvoxFEfUnZ2iCA3uimt, discarded microblock refs: []
2025-06-10 17:45:53,326 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:53,326 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:53,326 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:53,328 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 22Lwc6ZDr3Gi7JiiJFYb2arZm16G3Xmt9xUZtpmddWNQ evaluated to Right(true)
2025-06-10 17:45:53,329 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 9QNC61S5apxcUDk5XLuR3HgEbBPyYkUdRzeQrTJvTdv5 evaluated to Right(true)
2025-06-10 17:45:53,329 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(A6QG6jJ... -> GP61vxd..., txs=3) appended, diff=59289325
2025-06-10 17:45:53,334 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(DgPzRFL... -> A6QG6jJ..., txs=1) appended, diff=ef3c72a1
2025-06-10 17:45:53,334 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:53,334 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:53,334 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:53,335 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:53,336 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:53,337 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:53,337 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:53,492 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction AwQr1E5WHjuGfy9rcfz3r6xfDgoe5qX78MXmnqEsncDj evaluated to Right(true)
2025-06-10 17:45:53,495 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 5SczTDTCYuWwN6ShNPgT6j6p43vnVnnfAbJ8FzrUXnBj evaluated to Right(true)
2025-06-10 17:45:53,496 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 4mstj7zZhwR3zVw9zPLQf3ix37jNumgCfzdapmP9hTmU4Je9N3pKRjZ254mkaXvjS7WhhtF5bXtBSzKqi9MeCGuX, discarded microblock refs: []
2025-06-10 17:45:53,498 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:53,498 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:53,498 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:53,500 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction EctDQjZeaA3txUk83TvGCmU3kexRkpkCw2MsnNXbCifo evaluated to Right(true)
2025-06-10 17:45:53,501 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction BM42Hc1RZL3kvuqFLwVcWaCpAZnLedGYm9j71cBhMX9d evaluated to Right(true)
2025-06-10 17:45:53,502 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(vQHmuNC... -> BYGbL1V..., txs=3) appended, diff=38afa4b5
2025-06-10 17:45:53,504 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction g55mR8Zy9bKrjx65FApsCnST6yU5LAR8P2qScVnMhoH evaluated to Right(true)
2025-06-10 17:45:53,510 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(7CdZm7x... -> vQHmuNC..., txs=1) appended, diff=166a928a
2025-06-10 17:45:53,514 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(7yfGLpy... -> 7CdZm7x..., txs=1) appended, diff=76909e7b
2025-06-10 17:45:53,514 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:53,514 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:53,515 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:53,516 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:53,516 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:53,518 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:53,518 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:53,683 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 6kYyhPbw4BXpGzmEMJdHJ7XJeGuDDuNVxTNMs1ufCRyz evaluated to Right(true)
2025-06-10 17:45:53,685 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction Gc31qHAyFv4nugqjdg2UCe6sqj1FUpeTn9bgQcRaQA4o evaluated to Right(true)
2025-06-10 17:45:53,687 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 3WEsPxitLrxWTxtu9ipJr5NpYfkX833k5psX5MxK1mxZPMJxSQb4dFLs2kUyaNFN1AmRRN4cxGezQyW6qsxVUTsn, discarded microblock refs: []
2025-06-10 17:45:53,688 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:53,688 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:53,688 DEBUG [nsfersTestSuite] units.ELUpdater - Waiting for at least one joined miner
2025-06-10 17:45:53,690 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(ARBQQWH... -> GzBaaYZ..., txs=2) appended, diff=c8396d19
2025-06-10 17:45:53,692 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction AWk1eqH3j7iJT6Z4NbhWbZs6zmKRoc9ZYoy5Xtk28mwd evaluated to Right(true)
2025-06-10 17:45:53,696 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(FYA1d3f... -> ARBQQWH..., txs=1) appended, diff=8eed91ba
2025-06-10 17:45:53,699 TRACE [nsfersTestSuite] units.ExtensionDomain - close
2025-06-10 17:45:53,699 TRACE [nsfersTestSuite] units.ExtensionDomain - triggerScheduledTasks
2025-06-10 17:45:53,702 TRACE [nsfersTestSuite] c.w.utx.UtxPoolImpl.trace - Validation trace reporting is enabled
2025-06-10 17:45:53,703 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #1
2025-06-10 17:45:53,703 INFO  [nsfersTestSuite] c.w.w.Wallet$WalletImpl - Added account #2
2025-06-10 17:45:53,705 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 1
2025-06-10 17:45:53,705 DEBUG [nsfersTestSuite] u.C2ETransfersTestSuite - EL init
2025-06-10 17:45:53,868 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction Khu8xyEzWCdGNYToEEgDwoQhqNA4t9c5D352EeJnJuq evaluated to Right(true)
2025-06-10 17:45:53,870 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 59iizhJWJnXHWzfQyajntCmz8XVhGhvBECoFiSc1jAJu evaluated to Right(true)
2025-06-10 17:45:53,878 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 3ZLt92TDfCjPBPbzGKkgD8spLFiEoWJjUSaNa4EkkU6b8dg3hX3BbX3H8inHboXS7GpexXSZjmwu3WxycHP7JTAB, discarded microblock refs: []
2025-06-10 17:45:53,880 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 2
2025-06-10 17:45:53,880 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:53,883 DEBUG [nsfersTestSuite] units.ELUpdater - Finalized block is 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:53,884 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [78393] getBlockByHash(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:53,884 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [78393] Success: EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={})
2025-06-10 17:45:53,884 TRACE [nsfersTestSuite] units.ELUpdater - Finalized block 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is at height 0
2025-06-10 17:45:53,891 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [53665] getLastExecutionBlock
2025-06-10 17:45:53,892 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [53665] Success: EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={})
2025-06-10 17:45:53,892 TRACE [nsfersTestSuite] units.ELUpdater - Following main chain 0
2025-06-10 17:45:53,894 TRACE [nsfersTestSuite] units.ELUpdater - New state after 3: Working(EpochInfo(2,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,FbggYp3KXWSNKgbhiBk98rG1JmCFnyGcwX5M9JrCfUc6,None),EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),None),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:53,894 TRACE [nsfersTestSuite] units.ELUpdater - EC chain 0 is synced, no need to request blocks
2025-06-10 17:45:53,896 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction Girb7NPrWjYemsCEzPzRvEU71m7mygFLs4Rsf61oGfwe evaluated to Right(true)
2025-06-10 17:45:53,897 TRACE [nsfersTestSuite] c.w.t.smart.Verifier$ - Script for transaction 9ctRc69vpVBroCpQWJYQG7Zz1yDYXnvtYjp71gmbrKKW evaluated to Right(true)
2025-06-10 17:45:53,899 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 3HFTXVezZB6B2ZoJyeZ5JNMiS9xzSr8cm1rfv1xQ1L8g, discarded microblock refs: []
2025-06-10 17:45:53,973 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 3
2025-06-10 17:45:53,973 INFO  [nsfersTestSuite] u.C2ETransfersTestSuite - ========= Start new epoch for ecBlock1 =========
2025-06-10 17:45:53,976 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block DJJn7vjfnGK2zikvi1aJfihb74xmHkjLAYBQS4ybVQmH, discarded microblock refs: []
2025-06-10 17:45:53,978 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 4
2025-06-10 17:45:54,011 DEBUG [nsfersTestSuite] units.ExtensionDomain - advanceNewBlocks: unexpected computed generator 3MrLHCBhcT1BpFd267WmVEABkdkf1krfMnd
2025-06-10 17:45:54,012 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 4xtJU1kbBxrzF7oVwvtoAvkgaot438rrQkdZZHWDuqGh, discarded microblock refs: []
2025-06-10 17:45:54,013 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 5
2025-06-10 17:45:54,017 DEBUG [nsfersTestSuite] units.ExtensionDomain - advanceNewBlocks: unexpected computed generator 3MrLHCBhcT1BpFd267WmVEABkdkf1krfMnd
2025-06-10 17:45:54,019 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 2aFBneBmAEjy2bJg87FGosmomdqsYTcWwiC6EDUAvZv9, discarded microblock refs: []
2025-06-10 17:45:54,019 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 6
2025-06-10 17:45:54,022 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:54,023 DEBUG [nsfersTestSuite] units.ELUpdater - Finalized block is 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:54,023 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [53786] getBlockByHash(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:54,023 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [53786] Success: EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={})
2025-06-10 17:45:54,023 TRACE [nsfersTestSuite] units.ELUpdater - Finalized block 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is at height 0
2025-06-10 17:45:54,024 TRACE [nsfersTestSuite] units.ELUpdater - New state after 16: Working(EpochInfo(6,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,GciBrWPMamUHgiFwJJRXLUx4KkcfbiTEgPfFpq96NZj5,Some(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)),EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),None),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:54,024 TRACE [nsfersTestSuite] units.ELUpdater - EC chain 0 is synced, no need to request blocks
2025-06-10 17:45:54,024 TRACE [nsfersTestSuite] units.ELUpdater - Designated miner in epoch 6 is 3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy
2025-06-10 17:45:54,034 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(GsTDZFh... -> 5UKTwfD..., txs=1) appended, diff=2c6b19a0
2025-06-10 17:45:54,035 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:54,035 DEBUG [nsfersTestSuite] units.ELUpdater - Finalized block is 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:54,035 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [42755] getBlockByHash(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:54,035 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [42755] Success: EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={})
2025-06-10 17:45:54,035 TRACE [nsfersTestSuite] units.ELUpdater - Finalized block 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is at height 0
2025-06-10 17:45:54,036 TRACE [nsfersTestSuite] units.ELUpdater - New state after 16: Working(EpochInfo(6,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,GciBrWPMamUHgiFwJJRXLUx4KkcfbiTEgPfFpq96NZj5,Some(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)),EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),None),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:54,036 DEBUG [nsfersTestSuite] units.ELUpdater - EC chain is not synced, trying to find next block to request
2025-06-10 17:45:54,036 DEBUG [nsfersTestSuite] units.ELUpdater - Requesting block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d
2025-06-10 17:45:54,036 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [64868] getBlockByHash(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)
2025-06-10 17:45:54,036 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [64868] Success: EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={})
2025-06-10 17:45:54,036 DEBUG [nsfersTestSuite] units.ELUpdater - Block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d exists at EC chain, trying to confirm
2025-06-10 17:45:54,036 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [72010] forkchoiceUpdated(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, f=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:54,037 DEBUG [nsfersTestSuite] u.client.TestEcClients - Curr chain: 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d <- 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:54,037 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [72010] Success: VALID
2025-06-10 17:45:54,037 TRACE [nsfersTestSuite] units.ELUpdater - New state after 7: Working(EpochInfo(6,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,GciBrWPMamUHgiFwJJRXLUx4KkcfbiTEgPfFpq96NZj5,Some(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)),EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),None),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:54,037 TRACE [nsfersTestSuite] units.ELUpdater - EC chain 0 is synced, no need to request blocks
2025-06-10 17:45:54,037 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [70812] getBlockByHash(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)
2025-06-10 17:45:54,037 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [70812] Success: EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={})
2025-06-10 17:45:54,037 DEBUG [nsfersTestSuite] units.ELUpdater - Trying to validate applied block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d
2025-06-10 17:45:54,038 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [77656] getLogs(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, a={0xa50a51c09a5c451c52bb714527e1974b686d8e77, 0x0000000000000000000000000000000000006a7e}, t={})
2025-06-10 17:45:54,038 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [77656] Success: {}
2025-06-10 17:45:54,041 TRACE [nsfersTestSuite] units.ELUpdater - New state after 5: Working(EpochInfo(6,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,GciBrWPMamUHgiFwJJRXLUx4KkcfbiTEgPfFpq96NZj5,Some(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)),EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1),Some(-1)),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:54,041 DEBUG [nsfersTestSuite] units.ELUpdater - Block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d was successfully validated
2025-06-10 17:45:54,041 INFO  [nsfersTestSuite] u.C2ETransfersTestSuite - ========= Start a new epoch of miner 3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy =========
2025-06-10 17:45:54,043 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block GsTDZFhFxiAtJmP2HcQrcZYRdQRyy9jfr1QvP9GYnnTq, discarded microblock refs: []
2025-06-10 17:45:54,044 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 7
2025-06-10 17:45:54,048 DEBUG [nsfersTestSuite] units.ExtensionDomain - advanceNewBlocks: unexpected computed generator 3MrLHCBhcT1BpFd267WmVEABkdkf1krfMnd
2025-06-10 17:45:54,049 TRACE [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - Persisting block 8jUV2DcsnPz3PQzWB4E3eXm1oX1aYatmXreBvoavagSG, discarded microblock refs: []
2025-06-10 17:45:54,049 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - New height: 8
2025-06-10 17:45:54,053 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:54,053 DEBUG [nsfersTestSuite] units.ELUpdater - Finalized block is 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:54,053 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [39410] getBlockByHash(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:54,053 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [39410] Success: EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={})
2025-06-10 17:45:54,053 TRACE [nsfersTestSuite] units.ELUpdater - Finalized block 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is at height 0
2025-06-10 17:45:54,054 TRACE [nsfersTestSuite] units.ELUpdater - New state after 16: Working(EpochInfo(8,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,DX1aVXC7acubMXpjXys4t1edRwot6tcBR3A7bQU1XRSv,Some(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)),EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1),Some(-1)),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:54,054 TRACE [nsfersTestSuite] units.ELUpdater - EC chain 0 is synced, no need to request blocks
2025-06-10 17:45:54,054 TRACE [nsfersTestSuite] units.ELUpdater - Designated miner in epoch 8 is 3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy
2025-06-10 17:45:54,054 INFO  [nsfersTestSuite] u.C2ETransfersTestSuite - ========= Append a CL micro block with ecBlock2 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d confirmation =========
2025-06-10 17:45:54,061 INFO  [nsfersTestSuite] c.w.s.BlockchainUpdaterImpl - MicroBlock(3F5Zmq7... -> EvYJpcC..., txs=1) appended, diff=da3e6057
2025-06-10 17:45:54,061 TRACE [nsfersTestSuite] units.ExtensionDomain - advanceConsensusLayerChanged(50 milliseconds)
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] units.ELUpdater - Finalized block is 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [46131] getBlockByHash(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [46131] Success: EcBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, h=0, t=1749563147, m=0x0000000000000000000000000000000000000000, w={})
2025-06-10 17:45:54,061 TRACE [nsfersTestSuite] units.ELUpdater - Finalized block 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is at height 0
2025-06-10 17:45:54,061 TRACE [nsfersTestSuite] units.ELUpdater - New state after 16: Working(EpochInfo(8,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,DX1aVXC7acubMXpjXys4t1edRwot6tcBR3A7bQU1XRSv,Some(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)),EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, e=8, h=2, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1),Some(-1)),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, e=8, h=2, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] units.ELUpdater - EC chain is not synced, trying to find next block to request
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] units.ELUpdater - Requesting block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [20557] getBlockByHash(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [20557] Success: EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={})
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] units.ELUpdater - Block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d exists at EC chain, trying to confirm
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [20283] forkchoiceUpdated(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, f=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] u.client.TestEcClients - Curr chain: 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d <- 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [20283] Success: VALID
2025-06-10 17:45:54,061 TRACE [nsfersTestSuite] units.ELUpdater - New state after 7: Working(EpochInfo(8,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,DX1aVXC7acubMXpjXys4t1edRwot6tcBR3A7bQU1XRSv,Some(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)),EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, e=8, h=2, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1),Some(-1)),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, e=8, h=2, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:54,061 DEBUG [nsfersTestSuite] units.ELUpdater - EC chain is not synced, trying to find next block to request
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] units.ELUpdater - Requesting block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [27182] getBlockByHash(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [27182] Success: EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={})
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] units.ELUpdater - Block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d exists at EC chain, trying to confirm
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [89166] forkchoiceUpdated(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, f=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.client.TestEcClients - Curr chain: 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d <- 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [89166] Success: VALID
2025-06-10 17:45:54,062 TRACE [nsfersTestSuite] units.ELUpdater - New state after 7: Working(EpochInfo(8,3MsY23LPQnvPZnBKpvs6YcnCvGjLVD42pSy,0x27b43c1b8fa4da1b9308c5406301d025cab6e153,DX1aVXC7acubMXpjXys4t1edRwot6tcBR3A7bQU1XRSv,Some(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)),EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={}),ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, e=8, h=2, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),FullValidationStatus(ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, e=6, h=1, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1),Some(-1)),FollowingChain(ChainInfo(0,true,ContractBlock(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, p=0x0000000000000000000000000000000000000000000000000000000000000000, e=2, h=0, m=0x0000000000000000000000000000000000000000, c=0, e2c=, c2e=-1, lari=-1),ContractBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, e=8, h=2, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, c=0, e2c=, c2e=-1, lari=-1)),None),ChainContractOptions(2000000000 Gwei,0x0000000000000000000000000000000000006a7e,Some(0xa50a51c09a5c451c52bb714527e1974b686d8e77),0),None,false)
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] units.ELUpdater - EC chain is not synced, trying to find next block to request
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] units.ELUpdater - Requesting block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [61150] getBlockByHash(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d)
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [61150] Success: EcBlock(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, p=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, h=1, t=1749563153, m=0x27b43c1b8fa4da1b9308c5406301d025cab6e153, w={})
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] units.ELUpdater - Block 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d exists at EC chain, trying to confirm
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [16234] forkchoiceUpdated(0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d, f=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470)
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.client.TestEcClients - Curr chain: 0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d <- 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
2025-06-10 17:45:54,062 DEBUG [nsfersTestSuite] u.c.TestEcClients$$anon$1 - [16234] Success: VALID
2025-06-10 17:45:54,062 TRACE [nsfersTestSuite] units.ELUpdater - New state after 7: Working(...)
```